### PR TITLE
Change Spring2D to use properties

### DIFF
--- a/Runtime/Springs/Spring2D.cs
+++ b/Runtime/Springs/Spring2D.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -8,12 +8,41 @@ namespace Snowdrama.Spring
     public class Spring2D
     {
         SpringList springCollection;
-        Vector2 value;
-        Vector2 target;
-        Vector2 velocity;
-
         int xID;
         int yID;
+        
+        public Vector2 Value {
+            get {
+                return new Vector2(springCollection.GetValue(xID), springCollection.GetValue(yID));
+            }
+            set {
+                return new Vector2(springCollection.SetValue(xID, value.x), springCollection.SetValue(yID, value.y));
+            }
+        }
+        public Vector2 Target {
+            get {
+                return new Vector2(springCollection.GetTarget(xID), springCollection.GetTarget(yID));
+            }
+            set {
+                return new Vector2(springCollection.SetTarget(xID, value.x), springCollection.SetTarget(yID, value.y));
+            }
+        }
+        public Vector2 Velocity {
+            get {
+                return new Vector2(springCollection.GetVelocity(xID), springCollection.GetVelocity(yID));
+            }
+            set {
+                return new Vector2(springCollection.SetVelocity(xID, value.x), springCollection.SetVelocity(yID, value.y));
+            }
+        }
+        
+        public SpringConfig SpringConfig {
+            set{
+                springCollection.SetSpringConfig(xID, value);
+                springCollection.SetSpringConfig(yID, value);
+            }
+        }
+        
         public Spring2D(SpringConfiguration config, Vector2 initialValue = new Vector2())
         {
             springCollection = new SpringList();
@@ -24,52 +53,6 @@ namespace Snowdrama.Spring
         public void Update(float deltaTime)
         {
             springCollection.Update(deltaTime);
-            value.x = springCollection.GetValue(xID);
-            value.y = springCollection.GetValue(yID);
-        }
-
-        public void SetTarget(Vector2 position)
-        {
-            springCollection.SetTarget(xID, position.x);
-            springCollection.SetTarget(yID, position.y);
-        }
-
-        public void SetValue(Vector2 position)
-        {
-            springCollection.SetValue(xID, position.x);
-            springCollection.SetValue(yID, position.y);
-        }
-
-        public void SetVelocity(Vector2 position)
-        {
-            springCollection.SetVelocity(xID, position.x);
-            springCollection.SetVelocity(yID, position.y);
-        }
-
-        public void SetSpringConfig(SpringConfiguration config)
-        {
-            springCollection.SetSpringConfig(xID, config);
-            springCollection.SetSpringConfig(yID, config);
-        }
-        public Vector3 GetTarget()
-        {
-            target.x = springCollection.GetTarget(xID);
-            target.y = springCollection.GetTarget(yID);
-            return value;
-        }
-
-        public Vector3 GetValue()
-        {
-            value.x = springCollection.GetValue(xID);
-            value.y = springCollection.GetValue(yID);
-            return value;
-        }
-
-        public Vector3 GetVelocity()
-        {
-            velocity.x = springCollection.GetVelocity(xID);
-            velocity.y = springCollection.GetVelocity(yID);
-            return velocity;
         }
     }
 }

--- a/Runtime/Springs/Spring2D.cs
+++ b/Runtime/Springs/Spring2D.cs
@@ -10,39 +10,53 @@ namespace Snowdrama.Spring
         SpringList springCollection;
         int xID;
         int yID;
-        
-        public Vector2 Value {
-            get {
+
+        public Vector2 Value
+        {
+            get
+            {
                 return new Vector2(springCollection.GetValue(xID), springCollection.GetValue(yID));
             }
-            set {
-                return new Vector2(springCollection.SetValue(xID, value.x), springCollection.SetValue(yID, value.y));
+            set
+            {
+                springCollection.SetValue(xID, value.x);
+                springCollection.SetValue(yID, value.y);
             }
         }
-        public Vector2 Target {
-            get {
+        public Vector2 Target
+        {
+            get
+            {
                 return new Vector2(springCollection.GetTarget(xID), springCollection.GetTarget(yID));
             }
-            set {
-                return new Vector2(springCollection.SetTarget(xID, value.x), springCollection.SetTarget(yID, value.y));
+            set
+            {
+                springCollection.SetTarget(xID, value.x);
+                springCollection.SetTarget(yID, value.y);
             }
         }
-        public Vector2 Velocity {
-            get {
+        public Vector2 Velocity
+        {
+            get
+            {
                 return new Vector2(springCollection.GetVelocity(xID), springCollection.GetVelocity(yID));
             }
-            set {
-                return new Vector2(springCollection.SetVelocity(xID, value.x), springCollection.SetVelocity(yID, value.y));
+            set
+            {
+                springCollection.SetVelocity(xID, value.x);
+                springCollection.SetVelocity(yID, value.y);
             }
         }
-        
-        public SpringConfig SpringConfig {
-            set{
+
+        public SpringConfiguration SpringConfig
+        {
+            set
+            {
                 springCollection.SetSpringConfig(xID, value);
                 springCollection.SetSpringConfig(yID, value);
             }
         }
-        
+
         public Spring2D(SpringConfiguration config, Vector2 initialValue = new Vector2())
         {
             springCollection = new SpringList();


### PR DESCRIPTION
I had a typo which returned value instead of target when using GetTarget, changed the functions to public properties which avoids needing to store the local Vector2s int the Spring2D class and also avoid that typo, they just return values directly from the collection now